### PR TITLE
Fix KML attribute preservation for issue #54

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ This project showcases a simple geospatial data converter using [Streamlit](http
 ## Output formats
 CSV, KML, GeoJSON, TopoJSON, WKT, EsriJSON, GPX, ESRI Shapefile, OpenFileGDB
 
+KML exports preserve every selected attribute in both Google Earth-visible
+description tables and KML `ExtendedData`, so polygon metadata survives export
+and round-trips cleanly when the file is reloaded.
+
 ## Export options
 - **Reproject** to a target CRS before export (WGS 84, Web Mercator, NAD83, auto UTM zone, or any custom EPSG code)
 - **Select columns** to include in the output (single-file mode)

--- a/geospatial-data-converter/app.py
+++ b/geospatial-data-converter/app.py
@@ -31,7 +31,7 @@ INPUT_FORMAT_HELP = (
 
 OUTPUT_FORMAT_HELP = {
     "CSV": "Comma-separated values; geometry is serialised as WKT.",
-    "KML": "Google Earth Keyhole Markup Language.",
+    "KML": "Google Earth Keyhole Markup Language with full attribute tables preserved.",
     "GeoJSON": "RFC 7946 GeoJSON (text).",
     "TopoJSON": "Topology-preserving JSON.",
     "WKT": "One Well-Known Text geometry per line.",
@@ -401,8 +401,8 @@ elif len(datasets) == 1:
                 "Geometry types: "
                 + ", ".join(f"{t} ({n:,})" for t, n in geom_types.items()),
             )
-    except Exception:
-        pass  # nosec B110
+    except (AttributeError, TypeError, ValueError):
+        pass
 
     st.divider()
 

--- a/geospatial-data-converter/kml_tricks.py
+++ b/geospatial-data-converter/kml_tricks.py
@@ -3,7 +3,6 @@ from io import StringIO
 
 import bs4
 import geopandas as gpd
-import lxml  # nosec
 import pandas as pd
 from shapely.geometry import (
     Point,
@@ -148,17 +147,28 @@ def extract_data_from_kml_code(kml_code: str) -> pd.DataFrame:
     soup = bs4.BeautifulSoup(kml_code, features="xml")
 
     # Find all SchemaData tags (representing rows)
-    schema_data_tags = soup.find_all("schemadata")
+    schema_data_tags = soup.find_all(
+        lambda tag: tag.name and tag.name.lower() == "schemadata",
+    )
 
     # Create a generator that yields a dictionary for each row, containing the Placemark name and each SimpleData field
     row_dicts = (
         {
             "Placemark_name": (
-                tag.parent.parent.find("name").text
-                if tag.parent.parent.find("name")
+                tag.parent.parent.find(
+                    lambda child: child.name and child.name.lower() == "name",
+                ).text
+                if tag.parent.parent.find(
+                    lambda child: child.name and child.name.lower() == "name",
+                )
                 else "[no name]"
             ),
-            **{field.get("name"): field.text for field in tag.find_all("simpledata")},
+            **{
+                field.get("name"): field.text
+                for field in tag.find_all(
+                    lambda child: child.name and child.name.lower() == "simpledata",
+                )
+            },
         }
         for tag in schema_data_tags
     )
@@ -216,6 +226,13 @@ def extract_data_from_ge_file(file_path: str) -> gpd.GeoDataFrame:
     return geo_df
 
 
+def _is_lxml_parse_error(exc: Exception) -> bool:
+    return exc.__class__.__module__ == "lxml.etree" and exc.__class__.__name__ in {
+        "ParserError",
+        "XMLSyntaxError",
+    }
+
+
 def load_ge_data(file_path: str) -> gpd.GeoDataFrame:
     """Extracts data from a Google Earth file (KML or KMZ) and handles errors due to parsing issues"""
 
@@ -230,12 +247,12 @@ def load_ge_data(file_path: str) -> gpd.GeoDataFrame:
 
     try:
         data_df = primary_func(file_path)
-    except (
-        pd.errors.ParserError,
-        lxml.etree.ParserError,
-        lxml.etree.XMLSyntaxError,
-        ValueError,
-    ):
+    except Exception as exc:
+        if not (
+            isinstance(exc, (pd.errors.ParserError, ValueError))
+            or _is_lxml_parse_error(exc)
+        ):
+            raise
         data_df = fallback_func(file_path)
 
     return data_df

--- a/geospatial-data-converter/utils.py
+++ b/geospatial-data-converter/utils.py
@@ -3,9 +3,12 @@ import json
 import math
 import os
 import zipfile
+from html import escape
 import geopandas as gpd
 import pandas as pd
 import topojson
+from defusedxml import ElementTree as ET
+from pyogrio.errors import DataLayerError
 
 from pyproj import CRS
 from pyproj.exceptions import CRSError
@@ -50,6 +53,8 @@ _ESRI_WKID_ALIASES = {
     102100: 3857,
     102113: 3857,
 }
+
+_KML_NAMESPACE = "http://www.opengis.net/kml/2.2"
 
 
 def auto_utm_epsg_for_gdf(gdf: gpd.GeoDataFrame) -> int:
@@ -250,8 +255,8 @@ def read_gpx(file_path: str) -> gpd.GeoDataFrame:
     for layer in ("waypoints", "tracks", "routes", "track_points", "route_points"):
         try:
             gdf = gpd.read_file(file_path, layer=layer, engine="pyogrio")
-        except Exception:
-            continue  # nosec B112
+        except DataLayerError:
+            continue
         if len(gdf) > 0:
             return gdf
     # Fall back to driver default
@@ -316,6 +321,118 @@ def write_gpx(gdf: gpd.GeoDataFrame, out_path: str) -> None:
         engine="pyogrio",
         layer=layer,
     )
+
+
+def _kml_tag(tag_name: str) -> str:
+    return f"{{{_KML_NAMESPACE}}}{tag_name}"
+
+
+def _stringify_kml_value(value: object) -> str:
+    if pd.isna(value):
+        return ""
+    if hasattr(value, "item"):
+        value = value.item()
+    return str(value)
+
+
+def _kml_field_type(series: pd.Series) -> str:
+    if pd.api.types.is_bool_dtype(series):
+        return "bool"
+    if pd.api.types.is_integer_dtype(series):
+        return "int"
+    if pd.api.types.is_float_dtype(series):
+        return "double"
+    return "string"
+
+
+def _kml_description_table(attributes: dict[str, str]) -> str:
+    rows = "".join(
+        ("<tr>" f"<th>{escape(name)}</th>" f"<td>{escape(value)}</td>" "</tr>")
+        for name, value in attributes.items()
+    )
+    return (
+        '<table border="1" cellspacing="0" cellpadding="2">'
+        "<tbody>"
+        f"{rows}"
+        "</tbody></table>"
+    )
+
+
+def write_kml(gdf: gpd.GeoDataFrame, out_path: str) -> None:
+    gdf.to_file(out_path, driver="KML", engine="pyogrio")
+
+    geometry_column = gdf.geometry.name
+    attribute_columns = [column for column in gdf.columns if column != geometry_column]
+    if not attribute_columns:
+        return
+
+    tree = ET.parse(out_path)
+    root = tree.getroot()
+    document = root.find(_kml_tag("Document"))
+    if document is None:
+        raise ValueError("Generated KML is missing a Document element.")
+
+    schema = document.find(_kml_tag("Schema"))
+    if schema is None:
+        schema_name = os.path.splitext(os.path.basename(out_path))[0]
+        schema = document.makeelement(
+            _kml_tag("Schema"),
+            {"name": schema_name, "id": schema_name},
+        )
+        document.append(schema)
+
+    for child in list(schema):
+        if child.tag == _kml_tag("SimpleField"):
+            schema.remove(child)
+
+    for column in attribute_columns:
+        simple_field = schema.makeelement(
+            _kml_tag("SimpleField"),
+            {"name": str(column), "type": _kml_field_type(gdf[column])},
+        )
+        schema.append(simple_field)
+
+    placemarks = root.findall(f".//{_kml_tag('Placemark')}")
+    if len(placemarks) != len(gdf):
+        raise ValueError(
+            "Generated KML placemark count does not match the exported rows.",
+        )
+
+    for placemark, (_, row) in zip(
+        placemarks,
+        gdf.loc[:, attribute_columns].iterrows(),
+    ):
+        attributes = {
+            str(column): _stringify_kml_value(value) for column, value in row.items()
+        }
+
+        description = placemark.find(_kml_tag("description"))
+        if description is None:
+            description = placemark.makeelement(_kml_tag("description"), {})
+            placemark.append(description)
+        description.text = _kml_description_table(attributes)
+
+        extended_data = placemark.find(_kml_tag("ExtendedData"))
+        if extended_data is None:
+            extended_data = placemark.makeelement(_kml_tag("ExtendedData"), {})
+            placemark.append(extended_data)
+        for child in list(extended_data):
+            extended_data.remove(child)
+
+        schema_data = extended_data.makeelement(
+            _kml_tag("SchemaData"),
+            {"schemaUrl": f"#{schema.attrib.get('id', 'schema')}"},
+        )
+        extended_data.append(schema_data)
+        for name, value in attributes.items():
+            simple_data = schema_data.makeelement(
+                _kml_tag("SimpleData"),
+                {"name": name},
+            )
+            simple_data.text = value
+            schema_data.append(simple_data)
+
+    tree.write(out_path, encoding="utf-8", xml_declaration=True)
 
 
 def _esri_geometry_to_shapely(geom: dict):
@@ -449,6 +566,8 @@ def convert(gdf: gpd.GeoDataFrame, output_name: str, output_format: str) -> byte
                 esri_file.write(gdf_to_esrijson(gdf))
         elif output_format == "GPX":
             write_gpx(gdf, out_path)
+        elif output_format == "KML":
+            write_kml(gdf, out_path)
         else:
             gdf.to_file(out_path, driver=output_format, engine="pyogrio")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp==3.13.5
 beautifulsoup4==4.14.3
+defusedxml==0.7.1
 geopandas==1.1.3
 lxml==6.1.0
 numpy==2.4.4  # pinned for snyk

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import geopandas as gpd
 import pytest
+from defusedxml import ElementTree as ET
 from shapely.geometry import Point, Polygon
 
 from utils import (
@@ -105,3 +106,64 @@ def test_auto_utm_epsg_for_gdf_rejects_empty_geometry_frames() -> None:
 
     with pytest.raises(ValueError, match="at least one non-empty geometry"):
         auto_utm_epsg_for_gdf(gdf)
+
+
+def test_kml_conversion_preserves_all_attributes() -> None:
+    gdf = gpd.GeoDataFrame(
+        [
+            {
+                "alpha": "A",
+                "beta": "B",
+                "gamma": 3,
+                "geometry": Polygon([(0, 0), (0, 1), (1, 1), (1, 0)]),
+            },
+        ],
+        crs="EPSG:4326",
+    )
+
+    converted = convert(gdf, "issue54.kml", "KML")
+    root = ET.fromstring(converted)
+    namespace = {"kml": "http://www.opengis.net/kml/2.2"}
+
+    simple_fields = {
+        field.attrib["name"] for field in root.findall(".//kml:SimpleField", namespace)
+    }
+    assert simple_fields == {"alpha", "beta", "gamma"}
+
+    simple_data = {
+        field.attrib["name"]: field.text
+        for field in root.findall(".//kml:SimpleData", namespace)
+    }
+    assert simple_data == {"alpha": "A", "beta": "B", "gamma": "3"}
+
+    description = root.findtext(
+        ".//kml:Placemark/kml:description",
+        namespaces=namespace,
+    )
+    assert description is not None
+    for token in ("alpha", "A", "beta", "B", "gamma", "3"):
+        assert token in description
+
+
+def test_exported_kml_round_trips_all_attributes(tmp_path: Path) -> None:
+    original = gpd.GeoDataFrame(
+        [
+            {
+                "alpha": "A",
+                "beta": "B",
+                "gamma": 3,
+                "geometry": Polygon([(0, 0), (0, 1), (1, 1), (1, 0)]),
+            },
+        ],
+        crs="EPSG:4326",
+    )
+
+    output_path = tmp_path / "issue54.kml"
+    output_path.write_bytes(convert(original, output_path.name, "KML"))
+
+    with output_path.open("rb") as exported:
+        reloaded = read_file(exported)
+
+    assert reloaded.loc[0, "alpha"] == "A"
+    assert reloaded.loc[0, "beta"] == "B"
+    assert str(reloaded.loc[0, "gamma"]) == "3"


### PR DESCRIPTION
## Summary
Fixes #54.

This change fixes KML exports dropping or mis-mapping attributes, which caused zipped geodatabase exports to Google Earth to show incomplete metadata.

## Root Cause
The KML export path relied on the default GDAL/pyogrio KML writer behavior. That preserved geometry, but it did not serialize the full attribute set in a way that reliably survived into Google Earth placemark metadata or round-tripped back through the app.

## Changes
- add a dedicated KML writer that post-processes generated KML and writes every selected attribute into both:
  - KML `ExtendedData` / `SchemaData`
  - the placemark `description` table shown by Google Earth
- keep KML schema fields aligned with the exported attribute columns
- add regression coverage for:
  - preserving all exported attributes in KML output
  - round-tripping exported KML back through the loader with all attributes intact
- harden XML parsing by using `defusedxml` for KML post-processing
- remove existing Bandit suppressions by narrowing exception handling in the UI preview and GPX layer probing, and by removing the direct `lxml` import suppression
- document the KML attribute-preservation behavior in the README and UI help text

## Validation
- `python -m pytest -q`
- `pre-commit run --files README.md requirements.txt geospatial-data-converter/app.py geospatial-data-converter/kml_tricks.py geospatial-data-converter/utils.py tests/test_conversions.py`

## Notes
The existing GPX and shapefile warnings seen in the test suite are unchanged and pre-existing; they are format-level writer warnings, not regressions from this change.