### PR TITLE
Fix KMZ numeric fields being exported as text

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ KML exports preserve every selected attribute in both Google Earth-visible
 description tables and KML `ExtendedData`, so polygon metadata survives export
 and round-trips cleanly when the file is reloaded.
 
+KML and KMZ imports also preserve typed `SimpleData` fields from Google Earth
+schemas, so numeric attributes stay numeric when exported to ESRI Shapefile or
+OpenFileGDB.
+
 ## Export options
 - **Reproject** to a target CRS before export (WGS 84, Web Mercator, NAD83, auto UTM zone, or any custom EPSG code)
 - **Select columns** to include in the output (single-file mode)

--- a/geospatial-data-converter/kml_tricks.py
+++ b/geospatial-data-converter/kml_tricks.py
@@ -140,11 +140,56 @@ def load_ge_file(file_path: str) -> gpd.GeoDataFrame:
     raise ValueError("The file must have a .kml or .kmz extension.")
 
 
+def _simple_field_types(kml_soup: bs4.BeautifulSoup) -> dict[str, str]:
+    field_types: dict[str, str] = {}
+    for field in kml_soup.find_all(
+        lambda tag: tag.name and tag.name.lower() == "simplefield",
+    ):
+        name = field.get("name")
+        field_type = field.get("type")
+        if name and field_type:
+            field_types[name] = field_type.lower()
+    return field_types
+
+
+def _coerce_simple_field_value_types(
+    df: pd.DataFrame,
+    field_types: dict[str, str],
+) -> pd.DataFrame:
+    for column, field_type in field_types.items():
+        if column not in df.columns:
+            continue
+
+        if field_type in {"int", "uint", "short", "ushort"}:
+            numeric = pd.to_numeric(df[column], errors="coerce")
+            if numeric.notna().all():
+                df[column] = numeric.astype("Int64")
+        elif field_type in {"float", "double"}:
+            numeric = pd.to_numeric(df[column], errors="coerce")
+            if numeric.notna().all():
+                df[column] = numeric.astype("Float64")
+        elif field_type == "bool":
+            normalized = df[column].astype(str).str.strip().str.lower()
+            bool_map = {
+                "1": True,
+                "0": False,
+                "true": True,
+                "false": False,
+                "yes": True,
+                "no": False,
+            }
+            if normalized.isin(bool_map).all():
+                df[column] = normalized.map(bool_map).astype("boolean")
+
+    return df
+
+
 def extract_data_from_kml_code(kml_code: str) -> pd.DataFrame:
     """Extracts data from KML code into a DataFrame using SimpleData tags, excluding embedded tables in feature descriptions"""
 
     # Parse the KML source code
     soup = bs4.BeautifulSoup(kml_code, features="xml")
+    field_types = _simple_field_types(soup)
 
     # Find all SchemaData tags (representing rows)
     schema_data_tags = soup.find_all(
@@ -176,7 +221,7 @@ def extract_data_from_kml_code(kml_code: str) -> pd.DataFrame:
     # Convert the row dictionaries into a DataFrame
     df = pd.DataFrame(row_dicts)
 
-    return df
+    return _coerce_simple_field_value_types(df, field_types)
 
 
 def extract_kml_code_from_file(file_path: str) -> str:

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -3,6 +3,7 @@ import zipfile
 from pathlib import Path
 
 import geopandas as gpd
+import pandas as pd
 import pytest
 from defusedxml import ElementTree as ET
 from shapely.geometry import Point, Polygon
@@ -167,3 +168,56 @@ def test_exported_kml_round_trips_all_attributes(tmp_path: Path) -> None:
     assert reloaded.loc[0, "alpha"] == "A"
     assert reloaded.loc[0, "beta"] == "B"
     assert str(reloaded.loc[0, "gamma"]) == "3"
+
+
+def test_kmz_numeric_attributes_round_trip_to_shapefile(tmp_path: Path) -> None:
+    kmz_path = tmp_path / "numeric-fields.kmz"
+    kmz_xml = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<kml xmlns=\"http://www.opengis.net/kml/2.2\">
+    <Document>
+        <Schema id=\"parcel\">
+            <SimpleField name=\"acreage\" type=\"double\"/>
+            <SimpleField name=\"unit_count\" type=\"int\"/>
+            <SimpleField name=\"label\" type=\"string\"/>
+        </Schema>
+        <Placemark>
+            <name>parcel-a</name>
+            <ExtendedData>
+                <SchemaData schemaUrl=\"#parcel\">
+                    <SimpleData name=\"acreage\">12.5</SimpleData>
+                    <SimpleData name=\"unit_count\">3</SimpleData>
+                    <SimpleData name=\"label\">north</SimpleData>
+                </SchemaData>
+            </ExtendedData>
+            <Point><coordinates>-122.33,47.60,0</coordinates></Point>
+        </Placemark>
+    </Document>
+</kml>
+"""
+
+    with zipfile.ZipFile(kmz_path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("doc.kml", kmz_xml)
+
+    with kmz_path.open("rb") as uploaded:
+        loaded = read_file(uploaded)
+
+    assert loaded.loc[0, "label"] == "north"
+    assert pd.api.types.is_float_dtype(loaded["acreage"])
+    assert pd.api.types.is_integer_dtype(loaded["unit_count"])
+    assert loaded.loc[0, "acreage"] == pytest.approx(12.5)
+    assert loaded.loc[0, "unit_count"] == 3
+
+    converted = convert(loaded, "numeric-fields.shp", "ESRI Shapefile")
+    extracted_dir = tmp_path / "shapefile"
+    extracted_dir.mkdir()
+    with zipfile.ZipFile(io.BytesIO(converted)) as archive:
+        archive.extractall(extracted_dir)
+
+    shapefile = next(extracted_dir.glob("*.shp"))
+    round_tripped = gpd.read_file(shapefile, engine="pyogrio")
+
+    assert round_tripped.loc[0, "label"] == "north"
+    assert pd.api.types.is_float_dtype(round_tripped["acreage"])
+    assert pd.api.types.is_integer_dtype(round_tripped["unit_count"])
+    assert round_tripped.loc[0, "acreage"] == pytest.approx(12.5)
+    assert round_tripped.loc[0, "unit_count"] == 3


### PR DESCRIPTION
Closes #33

## Summary
- coerce KML/KMZ `SimpleData` values to their declared `SimpleField` types during import
- add a regression test covering KMZ -> ESRI Shapefile round-tripping of numeric attributes
- document that typed KML/KMZ schema fields stay numeric in Shapefile and OpenFileGDB exports

## Problem
KMZ files with schema-backed numeric attributes were loading those values as strings. When users exported that data to ESRI Shapefile, numeric fields like acreage and counts were written as text, which broke attribute queries in ArcGIS Pro.

## Fix
The loader now reads `SimpleField` type declarations from the KML schema and coerces matching `SimpleData` columns to numeric or boolean pandas dtypes before any downstream export. That keeps field types intact for shapefile and geodatabase writers.

## Validation
- `python -m pytest tests/test_conversions.py`
- `python -m pytest`
- `pre-commit run --all-files`

## Notes
The test exercises the full KMZ import and shapefile export path with `double`, `int`, and `string` fields to confirm both values and dtypes survive the round-trip.