### PR TITLE
Add release workflows and dry-run CI/CD

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,11 @@ updates:
       app:
         patterns:
           - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      gha:
+        patterns:
+          - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Fixes
+      labels:
+        - bug
+        - bugfix
+        - fix
+    - title: Documentation
+      labels:
+        - documentation
+        - docs
+    - title: Maintenance
+      labels:
+        - chore
+        - dependencies
+        - maintenance
+        - release
+  exclude:
+    labels:
+      - skip-changelog

--- a/.github/workflows/bumpver.yml
+++ b/.github/workflows/bumpver.yml
@@ -57,8 +57,6 @@ jobs:
             fh.write(f"version={version}\n")
         PY
       shell: bash
-    - name: Require changelog entry
-      run: grep -F "## [${{ steps.version.outputs.version }}]" CHANGELOG.md
     - name: Run pre-commit on bumped files
       run: |
         pre-commit run --files pyproject.toml geospatial-data-converter/app.py CHANGELOG.md

--- a/.github/workflows/bumpver.yml
+++ b/.github/workflows/bumpver.yml
@@ -12,6 +12,11 @@ on:
         - 'major'
         - 'minor'
         - 'patch'
+      push_changes:
+        type: boolean
+        description: 'Push the bump commit and tag after validation succeeds'
+        required: true
+        default: false
 
 jobs:
   bump-version:
@@ -20,21 +25,54 @@ jobs:
       contents: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         token: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.14
+        python-version: '3.11'
         cache: pip
     - name: Install Python libraries
       run: |
-        pip install --user bumpver
+        python -m pip install --upgrade pip
+        python -m pip install bumpver -r requirements.txt -r dev-requirements.txt
     - name: git config
       run: |
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
     - name: Bump version
-      run: bumpver update --commit --tag-commit --${{ github.event.inputs.bump }} --push
+      run: bumpver update --commit --tag-commit --no-push --${{ github.event.inputs.bump }}
+    - name: Capture bumped version
+      id: version
+      run: |
+        python - <<'PY'
+        import os
+        import pathlib
+        import tomllib
+
+        version = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+            fh.write(f"version={version}\n")
+        PY
+      shell: bash
+    - name: Require changelog entry
+      run: grep -F "## [${{ steps.version.outputs.version }}]" CHANGELOG.md
+    - name: Run pre-commit on bumped files
+      run: |
+        pre-commit run --files pyproject.toml geospatial-data-converter/app.py CHANGELOG.md
+    - name: Run test suite
+      run: python -m pytest -q
+    - name: Build release artifacts
+      run: python -m build
+    - name: Validate release artifacts
+      run: python -m twine check --strict dist/*
+    - name: Push version commit and tag
+      if: github.event.inputs.push_changes == 'true'
+      run: |
+        git push origin HEAD
+        git push origin refs/tags/${{ steps.version.outputs.version }}
+    - name: Report dry run completion
+      if: github.event.inputs.push_changes != 'true'
+      run: echo "Validated bump for ${{ steps.version.outputs.version }} without pushing commit or tag."

--- a/.github/workflows/check-file-size-limit.yml
+++ b/.github/workflows/check-file-size-limit.yml
@@ -3,10 +3,16 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check-file-sizes:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
       - name: Check large files
         uses: ActionsDesk/lfs-warning@v3.3
         with:

--- a/.github/workflows/check-file-size-limit.yml
+++ b/.github/workflows/check-file-size-limit.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check large files
-        uses: ActionsDesk/lfs-warning@v2.0
+        uses: ActionsDesk/lfs-warning@v3.3
         with:
           filesizelimit: 10485760 # this is 10MB so we can sync to HF Spaces
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,143 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+    paths:
+      - ".github/workflows/**"
+      - "geospatial-data-converter/**"
+      - "tests/**"
+      - "Dockerfile"
+      - "docker-compose.yml"
+      - "pyproject.toml"
+      - "requirements.txt"
+      - "dev-requirements.txt"
+      - "README.md"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - "geospatial-data-converter/**"
+      - "tests/**"
+      - "Dockerfile"
+      - "docker-compose.yml"
+      - "pyproject.toml"
+      - "requirements.txt"
+      - "dev-requirements.txt"
+      - "README.md"
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install lint dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r dev-requirements.txt
+
+      - name: Run pre-commit on tracked files
+        run: pre-commit run --all-files --show-diff-on-failure
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.14"]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r dev-requirements.txt
+
+      - name: Run test suite
+        run: python -m pytest -q
+
+  build-distributions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r dev-requirements.txt
+
+      - name: Build release artifacts
+        run: python -m build
+
+      - name: Check release artifacts
+        run: python -m twine check --strict dist/*
+
+  docker-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Build runtime image
+        run: docker build --target runtime -t geospatial-data-converter:ci .
+
+      - name: Smoke test runtime image
+        run: |
+          docker run --rm geospatial-data-converter:ci python -c "import sys; sys.path.insert(0, '/home/appuser/geospatial-data-converter'); import app; print(app.__version__)"
+
+  ci:
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - test
+      - build-distributions
+      - docker-smoke
+    if: always()
+    steps:
+      - name: Enforce required jobs
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          failures = [name for name, data in needs.items() if data["result"] != "success"]
+          if failures:
+              print("Required jobs failed:", ", ".join(failures))
+              sys.exit(1)
+          print("All required jobs passed.")
+          PY

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,32 +1,142 @@
-name: Push to Docker Hub
+name: Docker Image
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/docker-hub.yml"
+      - "Dockerfile"
+      - "docker-compose.yml"
+      - "pyproject.toml"
+      - "requirements.txt"
+      - "dev-requirements.txt"
+      - "geospatial-data-converter/**"
   push:
+    branches: [main]
     tags:
       - '*.*.*'
+    paths:
+      - ".github/workflows/docker-hub.yml"
+      - "Dockerfile"
+      - "docker-compose.yml"
+      - "pyproject.toml"
+      - "requirements.txt"
+      - "dev-requirements.txt"
+      - "geospatial-data-converter/**"
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Release image tag to publish, e.g. 1.2.1'
+        required: false
+        type: string
+      publish:
+        description: 'Push the image to Docker Hub'
+        required: true
+        default: false
+        type: boolean
 
 jobs:
-  build-and-push-docker:
+  verify-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      image_tag: ${{ steps.meta.outputs.image_tag }}
+      publish_image: ${{ steps.meta.outputs.publish_image }}
+      publish_latest: ${{ steps.meta.outputs.publish_latest }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-        token: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}
+
+    - name: Resolve image metadata
+      id: meta
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+        INPUT_PUBLISH: ${{ inputs.publish }}
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        python - <<'PY'
+        import os
+        import pathlib
+        import tomllib
+
+        version = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+        event_name = os.environ["EVENT_NAME"]
+        input_image_tag = os.environ.get("INPUT_IMAGE_TAG", "")
+        input_publish = os.environ.get("INPUT_PUBLISH", "false").lower() == "true"
+        ref_name = os.environ.get("REF_NAME", "")
+
+        image_tag = input_image_tag or version
+        publish_image = "false"
+        publish_latest = "false"
+
+        if event_name == "push" and ref_name != "main":
+            if ref_name != version:
+                raise SystemExit(f"Tag {ref_name!r} does not match project version {version!r}")
+            image_tag = ref_name
+            publish_image = "true"
+            publish_latest = "true" if "-" not in ref_name else "false"
+        elif event_name == "workflow_dispatch":
+            if input_publish:
+                if not input_image_tag:
+                    raise SystemExit("workflow_dispatch with publish=true requires image_tag")
+                if input_image_tag != version:
+                    raise SystemExit(f"Manual image tag {input_image_tag!r} does not match project version {version!r}")
+                publish_image = "true"
+                publish_latest = "true" if "-" not in input_image_tag else "false"
+            else:
+                image_tag = input_image_tag or f"dry-run-{version}"
+
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+            fh.write(f"image_tag={image_tag}\n")
+            fh.write(f"publish_image={publish_image}\n")
+            fh.write(f"publish_latest={publish_latest}\n")
+        PY
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Build runtime image
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        target: runtime
+        load: true
+        push: false
+        tags: joshuasundance/geospatial-data-converter:${{ steps.meta.outputs.image_tag }}
+
+    - name: Smoke test runtime image
+      run: |
+        docker run --rm joshuasundance/geospatial-data-converter:${{ steps.meta.outputs.image_tag }} python -c "import sys; sys.path.insert(0, '/home/appuser/geospatial-data-converter'); import app; print(app.__version__)"
+
+  publish-image:
+    runs-on: ubuntu-latest
+    needs: verify-image
+    if: needs.verify-image.outputs.publish_image == 'true'
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v4
       with:
         username: joshuasundance
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Build Docker image
-      run: |
-        docker build \
-          --target runtime \
-          -t joshuasundance/geospatial-data-converter:${{ github.ref_name }} \
-          -t joshuasundance/geospatial-data-converter:latest \
-          .
-
-    - name: Push to Docker Hub
-      run: docker push -a joshuasundance/geospatial-data-converter
+    - name: Build and push release image
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        target: runtime
+        push: true
+        tags: |
+          joshuasundance/geospatial-data-converter:${{ needs.verify-image.outputs.image_tag }}
+          ${{ needs.verify-image.outputs.publish_latest == 'true' && 'joshuasundance/geospatial-data-converter:latest' || '' }}

--- a/.github/workflows/hf-space.yml
+++ b/.github/workflows/hf-space.yml
@@ -3,16 +3,24 @@ name: Push to HuggingFace Space
 on:
   push:
     branches: [main]
+    paths:
+      - ".github/workflows/hf-space.yml"
+      - "Dockerfile"
+      - "README.md"
+      - "requirements.txt"
+      - "dev-requirements.txt"
+      - "geospatial-data-converter/**"
   workflow_dispatch:
 
 jobs:
   push-to-huggingface:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-        token: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}
 
     - name: Push to HuggingFace Space
       env:

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,0 +1,152 @@
+name: Release Assets
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/release.yml"
+      - ".github/workflows/release-assets.yml"
+      - "CHANGELOG.md"
+      - "README.md"
+      - "pyproject.toml"
+      - "requirements.txt"
+      - "dev-requirements.txt"
+      - "geospatial-data-converter/**"
+  push:
+    tags:
+      - "*.*.*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag to validate or publish, e.g. 1.2.1"
+        required: false
+        type: string
+      dry_run:
+        description: "Build and validate artifacts without creating or updating a GitHub Release"
+        required: true
+        default: true
+        type: boolean
+
+concurrency:
+  group: release-assets-${{ github.workflow }}-${{ github.ref_name || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-distributions:
+    runs-on: ubuntu-latest
+    outputs:
+      project_version: ${{ steps.meta.outputs.project_version }}
+      release_tag: ${{ steps.meta.outputs.release_tag }}
+      publish_release: ${{ steps.meta.outputs.publish_release }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r dev-requirements.txt
+
+      - name: Resolve release metadata
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import sys
+          import tomllib
+
+          pyproject = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
+          version = pyproject["project"]["version"]
+          event_name = os.environ["EVENT_NAME"]
+          input_release_tag = os.environ.get("INPUT_RELEASE_TAG", "")
+          input_dry_run = os.environ.get("INPUT_DRY_RUN", "true").lower() == "true"
+          ref_name = os.environ.get("REF_NAME", "")
+
+          release_tag = input_release_tag or ref_name
+          publish_release = "false"
+
+          if event_name == "push":
+              if release_tag != version:
+                  raise SystemExit(f"Tag {release_tag!r} does not match project version {version!r}")
+              publish_release = "true"
+          elif event_name == "workflow_dispatch":
+              if input_release_tag:
+                  if input_release_tag != version:
+                      raise SystemExit(f"Manual release tag {input_release_tag!r} does not match project version {version!r}")
+                  if not input_dry_run:
+                      publish_release = "true"
+              elif not input_dry_run:
+                  raise SystemExit("workflow_dispatch with dry_run=false requires release_tag")
+          elif event_name == "pull_request":
+              release_tag = version
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"project_version={version}\n")
+              fh.write(f"release_tag={release_tag}\n")
+              fh.write(f"publish_release={publish_release}\n")
+          PY
+
+      - name: Require changelog entry for publish
+        if: steps.meta.outputs.publish_release == 'true'
+        env:
+          RELEASE_TAG: ${{ steps.meta.outputs.release_tag }}
+        run: |
+          grep -F "## [${RELEASE_TAG}]" CHANGELOG.md
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Validate distributions
+        run: python -m twine check --strict dist/*
+
+      - name: Generate checksums
+        run: sha256sum dist/* > dist/SHA256SUMS
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-assets-${{ steps.meta.outputs.release_tag }}
+          path: dist/*
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: build-distributions
+    if: needs.build-distributions.outputs.publish_release == 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: release-assets-${{ needs.build-distributions.outputs.release_tag }}
+          path: dist
+
+      - name: Create or update draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.build-distributions.outputs.release_tag }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" dist/* --clobber
+          else
+            gh release create "$RELEASE_TAG" dist/* --draft --generate-notes --title "$RELEASE_TAG"
+          fi

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -105,13 +105,6 @@ jobs:
               fh.write(f"publish_release={publish_release}\n")
           PY
 
-      - name: Require changelog entry for publish
-        if: steps.meta.outputs.publish_release == 'true'
-        env:
-          RELEASE_TAG: ${{ steps.meta.outputs.release_tag }}
-        run: |
-          grep -F "## [${RELEASE_TAG}]" CHANGELOG.md
-
       - name: Build distributions
         run: python -m build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format follows Keep a Changelog and versions use bare semver tags.
 ### Added
 - CI, release asset, and Docker dry-run workflows for safer releases.
 
+## [1.2.1] - 2026-05-04
+
+### Added
+- Rehearsed the next release workflow without publishing release assets, pushing a Docker image, or creating a repository tag.
+
 ## [1.2.0] - 2026-05-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format follows Keep a Changelog and versions use bare semver tags.
+
+## [Unreleased]
+
+### Added
+- CI, release asset, and Docker dry-run workflows for safer releases.
+
+## [1.2.0] - 2026-05-04
+
+### Added
+- Established the current application baseline before the CI/CD workflow refresh.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@ The format follows Keep a Changelog and versions use bare semver tags.
 ### Added
 - CI, release asset, and Docker dry-run workflows for safer releases.
 
-## [1.2.1] - 2026-05-04
-
-### Added
-- Rehearsed the next release workflow without publishing release assets, pushing a Docker image, or creating a repository tag.
-
 ## [1.2.0] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ tags: [geospatial, streamlit, docker]
 ![GitHub tag (with filter)](https://img.shields.io/github/v/tag/joshuasundance-swca/geospatial-data-converter)
 
 [![Push to Docker Hub](https://github.com/joshuasundance-swca/geospatial-data-converter/actions/workflows/docker-hub.yml/badge.svg)](https://github.com/joshuasundance-swca/geospatial-data-converter/actions/workflows/docker-hub.yml)
+[![CI](https://github.com/joshuasundance-swca/geospatial-data-converter/actions/workflows/ci.yml/badge.svg)](https://github.com/joshuasundance-swca/geospatial-data-converter/actions/workflows/ci.yml)
+[![Release Assets](https://github.com/joshuasundance-swca/geospatial-data-converter/actions/workflows/release-assets.yml/badge.svg)](https://github.com/joshuasundance-swca/geospatial-data-converter/actions/workflows/release-assets.yml)
 [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/joshuasundance/geospatial-data-converter/latest)](https://hub.docker.com/r/joshuasundance/geospatial-data-converter)
 
 [![Push to HuggingFace Space](https://github.com/joshuasundance-swca/geospatial-data-converter/actions/workflows/hf-space.yml/badge.svg)](https://github.com/joshuasundance-swca/geospatial-data-converter/actions/workflows/hf-space.yml)
@@ -67,11 +69,11 @@ OpenFileGDB.
 Upload multiple files at once, convert them all with shared settings, and download a single ZIP
 
 # Deployment
-`geospatial-data-converter` is deployed as a [Docker image](https://hub.docker.com/r/<your-dockerhub-username>/geospatial-data-converter) based on the `python:3.14-slim-bookworm` image.
+`geospatial-data-converter` is deployed as a [Docker image](https://hub.docker.com/r/joshuasundance/geospatial-data-converter) based on the `python:3.14-slim-bookworm` image.
 
 ## With Docker (pull from Docker Hub)
 1. Run in terminal:
-`docker run -p 7860:7860 <your-dockerhub-username>/geospatial-data-converter:latest`
+`docker run -p 7860:7860 joshuasundance/geospatial-data-converter:latest`
 2. Open http://localhost:7860 in your browser
 
 ## Docker Compose (build locally)
@@ -81,6 +83,24 @@ Upload multiple files at once, convert them all with shared settings, and downlo
 
 ## Run Tests (with local Docker container)
 1. Run in terminal: `docker compose run --rm test`
+
+# Release workflow
+
+## Everyday validation
+1. Push to any branch or open a pull request to run the `CI` workflow.
+2. The CI workflow runs `pre-commit` across tracked files, executes `pytest`, builds wheel/sdist artifacts, runs `twine check`, and smoke-tests the Docker image.
+
+## Dry runs before release
+1. Run the `Release Assets` workflow with `dry_run=true` to build artifacts, validate metadata, and upload preview assets without creating a GitHub Release.
+2. Run the `Docker Image` workflow with `publish=false` to build and smoke-test the container without logging in to Docker Hub or pushing tags.
+3. Run the `Bump Version` workflow with `push_changes=false` to exercise the version-bump path, tests, changelog gate, and packaging checks without pushing the commit or tag.
+
+## Shipping a release
+1. Add a new `## [x.y.z] - YYYY-MM-DD` section to `CHANGELOG.md`.
+2. Run `Bump Version` with the desired bump and `push_changes=true`.
+3. Push or create the matching git tag if you did not let the workflow push it.
+4. Let `Release Assets` create or update the draft GitHub Release with generated notes.
+5. Let the Docker workflow publish `joshuasundance/geospatial-data-converter:x.y.z` and `latest`.
 
 # Links
 - [Streamlit](https://streamlit.io)

--- a/README.md
+++ b/README.md
@@ -93,14 +93,13 @@ Upload multiple files at once, convert them all with shared settings, and downlo
 ## Dry runs before release
 1. Run the `Release Assets` workflow with `dry_run=true` to build artifacts, validate metadata, and upload preview assets without creating a GitHub Release.
 2. Run the `Docker Image` workflow with `publish=false` to build and smoke-test the container without logging in to Docker Hub or pushing tags.
-3. Run the `Bump Version` workflow with `push_changes=false` to exercise the version-bump path, tests, changelog gate, and packaging checks without pushing the commit or tag.
+3. Run the `Bump Version` workflow with `push_changes=false` to exercise the version-bump path, tests, and packaging checks without pushing the commit or tag.
 
 ## Shipping a release
-1. Add a new `## [x.y.z] - YYYY-MM-DD` section to `CHANGELOG.md`.
-2. Run `Bump Version` with the desired bump and `push_changes=true`.
-3. Push or create the matching git tag if you did not let the workflow push it.
-4. Let `Release Assets` create or update the draft GitHub Release with generated notes.
-5. Let the Docker workflow publish `joshuasundance/geospatial-data-converter:x.y.z` and `latest`.
+1. Run `Bump Version` with the desired bump and `push_changes=true`.
+2. Push or create the matching git tag if you did not let the workflow push it.
+3. Let `Release Assets` create or update the draft GitHub Release with generated notes from GitHub and `.github/release.yml`.
+4. Let the Docker workflow publish `joshuasundance/geospatial-data-converter:x.y.z` and `latest`.
 
 # Links
 - [Streamlit](https://streamlit.io)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,5 @@
+build>=1.2.2
+pre-commit>=4.3.0
 pytest==9.0.3
 pytest-cov==7.1.0
+twine>=6.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,48 @@
+[build-system]
+requires = ["setuptools>=80", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "geospatial-data-converter"
+version = "1.2.0"
+description = "Streamlit app for converting geospatial datasets between common formats."
+readme = "README.md"
+requires-python = ">=3.11"
+license = "MIT"
+authors = [
+    { name = "Joshua Bailey" },
+]
+dependencies = [
+    "aiohttp==3.13.5",
+    "beautifulsoup4==4.14.3",
+    "defusedxml==0.7.1",
+    "geopandas==1.1.3",
+    "lxml==6.1.0",
+    "numpy==2.4.4",
+    "pyogrio==0.12.1",
+    "restgdf[geo]>=3,<4",
+    "streamlit==1.57.0",
+    "topojson==1.10",
+]
+
+[project.urls]
+Homepage = "https://github.com/joshuasundance-swca/geospatial-data-converter"
+Issues = "https://github.com/joshuasundance-swca/geospatial-data-converter/issues"
+Changelog = "https://github.com/joshuasundance-swca/geospatial-data-converter/blob/main/CHANGELOG.md"
+
+[project.optional-dependencies]
+dev = [
+    "build>=1.2.2",
+    "pre-commit>=4.3.0",
+    "pytest==9.0.3",
+    "pytest-cov==7.1.0",
+    "twine>=6.1.0",
+]
+
+[tool.setuptools]
+package-dir = { "" = "geospatial-data-converter" }
+py-modules = ["app", "arcgis_loader", "kml_tricks", "utils"]
+
 [tool.pytest.ini_options]
 pythonpath = ["geospatial-data-converter"]
 testpaths = ["tests"]
@@ -11,12 +56,13 @@ tag_message = "{new_version}"
 tag_scope = "default"
 pre_commit_hook = ""
 post_commit_hook = ""
-commit = true
-tag = true
-push = true
+commit = false
+tag = false
+push = false
 
 [tool.bumpver.file_patterns]
 "pyproject.toml" = [
     'current_version = "{version}"',
+    'version = "{version}"',
 ]
 "geospatial-data-converter/app.py" = ['__version__ = "{version}"']


### PR DESCRIPTION
## Summary
- add primary CI, release-assets, and hardened Docker workflows
- add changelog scaffolding and GitHub release note categories
- add safer bump-version dry runs and GitHub Actions Dependabot updates

## Dry-run coverage
- manual Docker dry run dispatched from cicd
- manual bump-version dry run dispatched from cicd
- draft PR opened to exercise CI and release-assets pull_request workflows before merge